### PR TITLE
Update scheduler.py

### DIFF
--- a/cosine_annealing_warmup/scheduler.py
+++ b/cosine_annealing_warmup/scheduler.py
@@ -86,3 +86,5 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
         self.last_epoch = math.floor(epoch)
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = lr
+            
+        self._last_lr = [group['lr'] for group in self.optimizer.param_groups]


### PR DESCRIPTION
Add tracking of last learning rate when using multiple parameters groups. I found this line in the source code of CosineAnnealingLR and thought was useful to have it also here