### PR TITLE
add CosineAnnealingRateWarmupRestarts based Warmup Rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,23 @@ pip install 'git+https://github.com/katsura-jp/pytorch-cosine-annealing-with-war
 ```
 
 ## Args
+### CosineAnnealingWarmupRestarts
 - optimizer (Optimizer): Wrapped optimizer.
 - first_cycle_steps (int): First cycle step size.
 - cycle_mult(float): Cycle steps magnification. Default: 1.
 - max_lr(float): First cycle's max learning rate. Default: 0.1.
 - min_lr(float): Min learning rate. Default: 0.001.
 - warmup_steps(int): Linear warmup step size. Default: 0.
+- gamma(float): Decrease rate of max learning rate by cycle. Default: 1.
+- last_epoch (int): The index of last epoch. Default: -1.
+
+### CosineAnnealingRateWarmupRestarts
+- optimizer (Optimizer): Wrapped optimizer.
+- first_cycle_steps (int): First cycle step size.
+- cycle_mult(float): Cycle steps magnification. Default: -1.
+- max_lr(float): First cycle's max learning rate. Default: 0.1.
+- min_lr(float): Min learning rate. Default: 0.001.
+- warmup_rate(float): Linear warmup rate of the current cycle's step size. Default: 0.
 - gamma(float): Decrease rate of max learning rate by cycle. Default: 1.
 - last_epoch (int): The index of last epoch. Default: -1.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install 'git+https://github.com/katsura-jp/pytorch-cosine-annealing-with-war
 - cycle_mult(float): Cycle steps magnification. Default: 1.
 - max_lr(float): First cycle's max learning rate. Default: 0.1.
 - min_lr(float): Min learning rate. Default: 0.001.
-- warmup_steps(int): Linear warmup step size. Default: 0.
+- **warmup_steps(int)**: Linear warmup step size. Default: 0.
 - gamma(float): Decrease rate of max learning rate by cycle. Default: 1.
 - last_epoch (int): The index of last epoch. Default: -1.
 
@@ -27,7 +27,7 @@ pip install 'git+https://github.com/katsura-jp/pytorch-cosine-annealing-with-war
 - cycle_mult(float): Cycle steps magnification. Default: -1.
 - max_lr(float): First cycle's max learning rate. Default: 0.1.
 - min_lr(float): Min learning rate. Default: 0.001.
-- warmup_rate(float): Linear warmup rate of the current cycle's step size. Default: 0.
+- **warmup_rate(float)**: Linear warmup rate of the current cycle's step size. Default: 0.
 - gamma(float): Decrease rate of max learning rate by cycle. Default: 1.
 - last_epoch (int): The index of last epoch. Default: -1.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pip install 'git+https://github.com/katsura-jp/pytorch-cosine-annealing-with-war
 - last_epoch (int): The index of last epoch. Default: -1.
 
 ## Example
+### CosineAnnealingWarmupRestarts
 ```
 >> from cosine_annealing_warmup import CosineAnnealingWarmupRestarts
 >>
@@ -43,3 +44,23 @@ pip install 'git+https://github.com/katsura-jp/pytorch-cosine-annealing-with-war
 ![example1](./src/plot001.png "example1")
 - case2 : `CosineAnnealingWarmupRestarts(optimizer, first_cycle_steps=200, cycle_mult=1.0, max_lr=0.1, min_lr=0.001, warmup_steps=50, gamma=0.5)`
 ![example2](./src/plot002.png "example2")
+
+### CosineAnnealingRateWarmupRestarts
+```
+>> from cosine_annealing_warmup import CosineAnnealingRateWarmupRestarts
+>>
+>> model = ...
+>> optimizer = optim.SGD(model.parameters(), lr=0.1, momentum=0.9, weight_decay=1e-5) # lr is min lr
+>> scheduler = CosineAnnealingRateWarmupRestarts(optimizer,
+                                          first_cycle_steps=100,
+                                          cycle_mult=2.0,
+                                          max_lr=0.1,
+                                          min_lr=0.001,
+                                          warmup_rate=0.1,
+                                          gamma=1.0)
+>> for epoch in range(n_epoch):
+>>     train()
+>>     valid()
+>>     scheduler.step()
+```
+- case1 : `CosineAnnealingRateWarmupRestarts(optimizer, first_cycle_steps=100, cycle_mult=2.0, max_lr=0.1, min_lr=0.001, warmup_rate=0.1, gamma=1.0)`

--- a/cosine_annealing_warmup/scheduler.py
+++ b/cosine_annealing_warmup/scheduler.py
@@ -86,3 +86,88 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
         self.last_epoch = math.floor(epoch)
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = lr
+
+class CosineAnnealingWarmupRestarts(_LRScheduler):
+    """
+        optimizer (Optimizer): Wrapped optimizer.
+        first_cycle_steps (int): First cycle step size.
+        cycle_mult(float): Cycle steps magnification. Default: -1.
+        max_lr(float): First cycle's max learning rate. Default: 0.1.
+        min_lr(float): Min learning rate. Default: 0.001.
+        warmup_steps(int): Linear warmup step size. Default: 0.
+        gamma(float): Decrease rate of max learning rate by cycle. Default: 1.
+        last_epoch (int): The index of last epoch. Default: -1.
+    """
+    
+    def __init__(self,
+                 optimizer : torch.optim.Optimizer,
+                 first_cycle_steps : int,
+                 cycle_mult : float = 1.,
+                 max_lr : float = 0.1,
+                 min_lr : float = 0.001,
+                 warmup_steps : int = 0,
+                 gamma : float = 1.,
+                 last_epoch : int = -1
+        ):
+        assert warmup_steps < first_cycle_steps
+        
+        self.first_cycle_steps = first_cycle_steps # first cycle step size
+        self.cycle_mult = cycle_mult # cycle steps magnification
+        self.base_max_lr = max_lr # first max learning rate
+        self.max_lr = max_lr # max learning rate in the current cycle
+        self.min_lr = min_lr # min learning rate
+        self.warmup_steps = warmup_steps # warmup step size
+        self.gamma = gamma # decrease rate of max learning rate by cycle
+        
+        self.cur_cycle_steps = first_cycle_steps # first cycle step size
+        self.cycle = 0 # cycle count
+        self.step_in_cycle = last_epoch # step size of the current cycle
+        
+        super(CosineAnnealingWarmupRestarts, self).__init__(optimizer, last_epoch)
+        
+        # set learning rate min_lr
+        self.init_lr()
+    
+    def init_lr(self):
+        self.base_lrs = []
+        for param_group in self.optimizer.param_groups:
+            param_group['lr'] = self.min_lr
+            self.base_lrs.append(self.min_lr)
+    
+    def get_lr(self):
+        if self.step_in_cycle == -1:
+            return self.base_lrs
+        elif self.step_in_cycle < self.warmup_steps:
+            return [(self.max_lr - base_lr)*self.step_in_cycle / self.warmup_steps + base_lr for base_lr in self.base_lrs]
+        else:
+            return [base_lr + (self.max_lr - base_lr) \
+                    * (1 + math.cos(math.pi * (self.step_in_cycle-self.warmup_steps) \
+                                    / (self.cur_cycle_steps - self.warmup_steps))) / 2
+                    for base_lr in self.base_lrs]
+
+    def step(self, epoch=None):
+        if epoch is None:
+            epoch = self.last_epoch + 1
+            self.step_in_cycle = self.step_in_cycle + 1
+            if self.step_in_cycle >= self.cur_cycle_steps:
+                self.cycle += 1
+                self.step_in_cycle = self.step_in_cycle - self.cur_cycle_steps
+                self.cur_cycle_steps = int((self.cur_cycle_steps - self.warmup_steps) * self.cycle_mult) + self.warmup_steps
+        else:
+            if epoch >= self.first_cycle_steps:
+                if self.cycle_mult == 1.:
+                    self.step_in_cycle = epoch % self.first_cycle_steps
+                    self.cycle = epoch // self.first_cycle_steps
+                else:
+                    n = int(math.log((epoch / self.first_cycle_steps * (self.cycle_mult - 1) + 1), self.cycle_mult))
+                    self.cycle = n
+                    self.step_in_cycle = epoch - int(self.first_cycle_steps * (self.cycle_mult ** n - 1) / (self.cycle_mult - 1))
+                    self.cur_cycle_steps = self.first_cycle_steps * self.cycle_mult ** (n)
+            else:
+                self.cur_cycle_steps = self.first_cycle_steps
+                self.step_in_cycle = epoch
+                
+        self.max_lr = self.base_max_lr * (self.gamma**self.cycle)
+        self.last_epoch = math.floor(epoch)
+        for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
+            param_group['lr'] = lr

--- a/cosine_annealing_warmup/scheduler.py
+++ b/cosine_annealing_warmup/scheduler.py
@@ -87,14 +87,14 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = lr
 
-class CosineAnnealingWarmupRestarts(_LRScheduler):
+class CosineAnnealingRateWarmupRestarts(_LRScheduler):
     """
         optimizer (Optimizer): Wrapped optimizer.
         first_cycle_steps (int): First cycle step size.
         cycle_mult(float): Cycle steps magnification. Default: -1.
         max_lr(float): First cycle's max learning rate. Default: 0.1.
         min_lr(float): Min learning rate. Default: 0.001.
-        warmup_steps(int): Linear warmup step size. Default: 0.
+        warmup_rate(float): Linear warmup rate of the current cycle's step size. Default: 0.
         gamma(float): Decrease rate of max learning rate by cycle. Default: 1.
         last_epoch (int): The index of last epoch. Default: -1.
     """
@@ -105,25 +105,26 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
                  cycle_mult : float = 1.,
                  max_lr : float = 0.1,
                  min_lr : float = 0.001,
-                 warmup_steps : int = 0,
+                 warmup_rate : float = 0.,
                  gamma : float = 1.,
                  last_epoch : int = -1
         ):
-        assert warmup_steps < first_cycle_steps
+        assert warmup_rate >= 0.
         
         self.first_cycle_steps = first_cycle_steps # first cycle step size
         self.cycle_mult = cycle_mult # cycle steps magnification
         self.base_max_lr = max_lr # first max learning rate
         self.max_lr = max_lr # max learning rate in the current cycle
         self.min_lr = min_lr # min learning rate
-        self.warmup_steps = warmup_steps # warmup step size
+        self.warmup_rate = warmup_rate # warmup rate of the current cycle's step size
         self.gamma = gamma # decrease rate of max learning rate by cycle
         
         self.cur_cycle_steps = first_cycle_steps # first cycle step size
         self.cycle = 0 # cycle count
         self.step_in_cycle = last_epoch # step size of the current cycle
+        self.warmup_steps_in_cycle = self.warmup_rate * self.cur_cycle_steps
         
-        super(CosineAnnealingWarmupRestarts, self).__init__(optimizer, last_epoch)
+        super(CosineAnnealingRateWarmupRestarts, self).__init__(optimizer, last_epoch)
         
         # set learning rate min_lr
         self.init_lr()
@@ -137,12 +138,12 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
     def get_lr(self):
         if self.step_in_cycle == -1:
             return self.base_lrs
-        elif self.step_in_cycle < self.warmup_steps:
-            return [(self.max_lr - base_lr)*self.step_in_cycle / self.warmup_steps + base_lr for base_lr in self.base_lrs]
+        elif self.step_in_cycle < self.warmup_steps_in_cycle:
+            return [(self.max_lr - base_lr)*self.step_in_cycle / self.warmup_steps_in_cycle + base_lr for base_lr in self.base_lrs]
         else:
             return [base_lr + (self.max_lr - base_lr) \
-                    * (1 + math.cos(math.pi * (self.step_in_cycle-self.warmup_steps) \
-                                    / (self.cur_cycle_steps - self.warmup_steps))) / 2
+                    * (1 + math.cos(math.pi * (self.step_in_cycle-self.warmup_steps_in_cycle) \
+                                    / (self.cur_cycle_steps - self.warmup_steps_in_cycle))) / 2
                     for base_lr in self.base_lrs]
 
     def step(self, epoch=None):
@@ -152,7 +153,7 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
             if self.step_in_cycle >= self.cur_cycle_steps:
                 self.cycle += 1
                 self.step_in_cycle = self.step_in_cycle - self.cur_cycle_steps
-                self.cur_cycle_steps = int((self.cur_cycle_steps - self.warmup_steps) * self.cycle_mult) + self.warmup_steps
+                self.cur_cycle_steps = int((self.cur_cycle_steps - self.warmup_steps_in_cycle) * self.cycle_mult) + self.warmup_steps_in_cycle
         else:
             if epoch >= self.first_cycle_steps:
                 if self.cycle_mult == 1.:
@@ -167,6 +168,7 @@ class CosineAnnealingWarmupRestarts(_LRScheduler):
                 self.cur_cycle_steps = self.first_cycle_steps
                 self.step_in_cycle = epoch
                 
+        self.warmup_steps_in_cycle = self.warmup_rate * self.cur_cycle_steps
         self.max_lr = self.base_max_lr * (self.gamma**self.cycle)
         self.last_epoch = math.floor(epoch)
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):


### PR DESCRIPTION
#### **Why This Change?**  
The original scheduler uses `warmup_steps` to define a fixed warmup step size. However, in scenarios where the cycle size dynamically changes due to `cycle_mult`, a fixed warmup size may not scale appropriately.  

Replacing `warmup_steps` with a **proportional warmup rate (`warmup_rate`)** ensures that the warmup step size adjusts dynamically based on the current cycle size. This provides more flexibility and consistency across varying cycle lengths.  

#### **What Has Changed?**  

1. **Replaced `warmup_steps` with `warmup_rate`**  
   - `warmup_rate` specifies the warmup step size as a fraction of the current cycle's total steps.
   - The warmup step size is computed as `cur_cycle_steps * warmup_rate`.  

2. **Added a New Class: `CosineAnnealingRateWarmupRestarts`**  
   - This class mirrors the functionality of the original `CosineAnnealingWarmupRestarts` but replaces `warmup_steps` with `warmup_rate`.  
   - Maintains compatibility with the existing implementation for users who prefer the old approach.  

3. **Additional Updates**  
   - Updated comments and Docstrings to reflect the changes.
   - Modified `get_lr` and `step` methods to handle the warmup rate logic.  

#### **Usage Example**  
```python
from cosine_annealing_warmup import CosineAnnealingRateWarmupRestarts

scheduler = CosineAnnealingRateWarmupRestarts(
    optimizer=optimizer,
    first_cycle_steps=100,  # Initial cycle size
    cycle_mult=2.0,        # Multiplier for subsequent cycle sizes
    max_lr=0.1,            # Maximum learning rate
    min_lr=0.001,          # Minimum learning rate
    warmup_rate=0.1,       # 10% of the current cycle size as warmup steps
    gamma=0.9,             # Decay factor for max_lr
)
```

### Testing
- Confirmed that warmup size scales dynamically with cycle size.

### Backward Compatibility
- The existing `CosineAnnealingWarmupRestarts` class remains unchanged, ensuring no breaking changes for users of the original implementation.


### **Note on README.md Images**  
Currently, the README.md does not include images or visualizations to illustrate the scheduler behavior. This is because I am not familiar with the best practices or tools for generating such images.  

If you have any suggestions or tools to recommend for visualizing learning rate schedules effectively, I would greatly appreciate your guidance or contributions!


*This Pull Request text is assisted by AI*